### PR TITLE
pppoe-server: Remove MAX_INTERFACES limitation.

### DIFF
--- a/src/pppoe-server.c
+++ b/src/pppoe-server.c
@@ -115,8 +115,9 @@ ClientSession *LastFreeSession = NULL;
 ClientSession *BusySessions = NULL;
 
 /* Interfaces we're listening on */
-Interface interfaces[MAX_INTERFACES];
+Interface *interfaces = NULL;
 int NumInterfaces = 0;
+int MaxInterfaces = 0;
 
 /* The number of session slots */
 size_t NumSessionSlots;
@@ -1235,10 +1236,15 @@ main(int argc, char **argv)
 	exit(1);
     }
 
-    memset(interfaces, 0, sizeof(interfaces));
-
     /* Initialize syslog */
     openlog("pppoe-server", LOG_PID, LOG_DAEMON);
+
+    MaxInterfaces = INIT_INTERFACES;
+    interfaces = malloc(sizeof(*interfaces) * INIT_INTERFACES);
+    if (!interfaces) {
+	fprintf(stderr, "Out of memory allocating initial interfaces.\n");
+	exit(1);
+    }
 
     /* Default number of session slots */
     NumSessionSlots = DEFAULT_MAX_SESSIONS;
@@ -1406,10 +1412,14 @@ main(int argc, char **argv)
 	    break;
 
 	case 'I':
-	    if (NumInterfaces >= MAX_INTERFACES) {
-		fprintf(stderr, "Too many -I options (max %d)\n",
-			MAX_INTERFACES);
-		exit(EXIT_FAILURE);
+	    if (NumInterfaces >= MaxInterfaces) {
+		MaxInterfaces *= 2;
+		interfaces = realloc(interfaces, sizeof(*interfaces) * MaxInterfaces);
+		if (!interfaces) {
+		    fprintf(stderr, "Memory allocation failure trying to increase MaxInterfaces to %d\n",
+			    MaxInterfaces);
+		    exit(EXIT_FAILURE);
+		}
 	    }
 	    found = 0;
 	    for (i=0; i<NumInterfaces; i++) {
@@ -1419,6 +1429,7 @@ main(int argc, char **argv)
 		}
 	    }
 	    if (!found) {
+		memset(&interfaces[NumInterfaces], 0, sizeof(*interfaces));
 		strncpy(interfaces[NumInterfaces].name, optarg, IFNAMSIZ);
 		NumInterfaces++;
 	    }

--- a/src/pppoe-server.h
+++ b/src/pppoe-server.h
@@ -97,8 +97,8 @@ typedef struct ClientSessionStruct {
 /* Hack for daemonizing */
 #define CLOSEFD 64
 
-/* Max. number of interfaces to listen on */
-#define MAX_INTERFACES 64
+/* Initial Max. number of interfaces to listen on */
+#define INIT_INTERFACES 8
 
 /* Max. 64 sessions by default */
 #define DEFAULT_MAX_SESSIONS 64
@@ -107,7 +107,7 @@ typedef struct ClientSessionStruct {
 extern ClientSession *Sessions;
 
 /* Interfaces we're listening on */
-extern Interface interfaces[MAX_INTERFACES];
+extern Interface *interfaces;
 extern int NumInterfaces;
 
 /* The number of session slots */


### PR DESCRIPTION
The value of 64 may seem reasonable, but ULS currently requires 77 and
this is likely to grow in the short to medium future, instead of
arbitrarily limiting allocate the memory dynamically.

Signed-off-by: Jaco Kroon <jaco@uls.co.za>