### PR TITLE
src/pppoe.h: fix build with musl libc

### DIFF
--- a/src/pppoe.h
+++ b/src/pppoe.h
@@ -117,10 +117,6 @@ typedef unsigned long UINT32_t;
 #error Could not find a 32-bit integer type
 #endif
 
-#ifdef HAVE_LINUX_IF_ETHER_H
-#include <linux/if_ether.h>
-#endif
-
 #include <netinet/in.h>
 
 #ifdef HAVE_NETINET_IF_ETHER_H
@@ -132,6 +128,10 @@ typedef unsigned long UINT32_t;
 #ifndef HAVE_SYS_DLPI_H
 #include <netinet/if_ether.h>
 #endif
+#endif
+
+#ifdef HAVE_LINUX_IF_ETHER_H
+#include <linux/if_ether.h>
 #endif
 
 


### PR DESCRIPTION
musl libc defines its own `struct ethhdr` that conflicts with the kernel define one. The kernel headers provide a way to suppress its `struct ethhdr`. For that to work the libc headers must precede the kernel. Move the kernel `linux/if_ether.h` include below libc `netinet/if_ether.h`. That fixes the following build failure:

```
In file included from pppoe.h:133,
                 from debug.c:19:
/home/giuliobenetti/autobuild/run/instance-0/output-1/host/riscv64-buildroot-linux-musl/sysroot/usr/include/netinet/if_ether.h:116:8: error: redefinition of 'struct ethhdr'
  116 | struct ethhdr {
      |        ^~~~~~
In file included from pppoe.h:121,
                 from debug.c:19:
/home/giuliobenetti/autobuild/run/instance-0/output-1/host/riscv64-buildroot-linux-musl/sysroot/usr/include/linux/if_ether.h:163:8: note: originally defined here
  163 | struct ethhdr {
      |        ^~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/ccca18fcbcde65cb6784f5559eac68ca17ab14a3

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>