### PR TITLE
fix krn plugin

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -4542,7 +4542,7 @@ modprobe ppp_synctty > /dev/null 2>&1
 modprobe pppoe > /dev/null 2>&1
 fi
 if test "$cross_compiling" = yes; then :
-  ac_cv_linux_kernel_pppoe=no; echo "cross-compiling, default: "
+  ac_cv_linux_kernel_pppoe=yes; echo "cross-compiling, default: "
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */

--- a/src/pppoe-server.c
+++ b/src/pppoe-server.c
@@ -25,6 +25,9 @@
 #include <net/if.h>
 #endif
 
+/* Patched hack to make this cross compile */
+#define HAVE_LINUX_KERNEL_PPPOE 1
+
 #if defined(HAVE_NETPACKET_PACKET_H) || defined(HAVE_LINUX_IF_PACKET_H)
 #define _POSIX_SOURCE 1 /* For sigaction defines */
 #endif


### PR DESCRIPTION
This patch has been added to buildroot more than eleven years ago with https://git.buildroot.net/buildroot/commit/?id=e9ae739ce757d73657ef860e21ccc78b3d55816e

[Retrieved from: https://git.buildroot.net/buildroot/tree/package/rp-pppoe/0001-krn-plugin.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>