### PR TITLE
pppoe-server:  drainfile option.

### DIFF
--- a/man/pppoe-server.8
+++ b/man/pppoe-server.8
@@ -34,6 +34,20 @@ This option causes \fBpppoe-server\fR to write its process ID to
 a single process may be started for a given \fIpidfile\fR.
 
 .TP
+.B \-D \fIdrainfile\fR
+This option causes \fBpppoe-server\fR to ignore PADI requests if drainfile
+exist.  This will not (currently) terminate the process once all active
+sessions have completed.
+
+This could potentially provide for seemless upgrades in that we can have one
+instance drain whilst a new instance starts up, you will however need to arrange
+that session ids do not overlap.
+
+\fBNOTE\fR:  There may be a performance impact since an access() system call is
+made on receipt of every PADI frame if this option is set.  Consider putting
+this destination on ramdisk (typically /run/).
+
+.TP
 .B \-q \fI/path/to/pppd\fR
 Specifies the full path to the \fBpppd\fR program.  The default is determined
 at compile time.  One use of this option is to supply a wrapper program that


### PR DESCRIPTION
This option allows for draining a pppoe-server instance, either for
redistributing load over time, or potentially for upgrade paths.

Signed-off-by: Jaco Kroon <jaco@uls.co.za>